### PR TITLE
docs: update readme with supported node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See [action.yml](./action.yml) for more detailed information.
 * timeout - The amount of time that Lambda allows a function to run before stopping it. The default is 3 seconds. The maximum allowed value is 900 seconds.
 * handler - The name of the method within your code that Lambda calls to execute your function.
 * role - The function's execution role. Pattern: `arn:(aws[a-zA-Z-]*)?:iam::\d{12}:role/?[a-zA-Z_0-9+=,.@\-_/]+`
-* runtime - The identifier of the function's runtime. `nodejs10.x | nodejs12.x | java8 | java8.al2 | java11 | python2.7 | python3.6 | python3.7 | python3.8 | dotnetcore2.1 | dotnetcore3.1 | go1.x | ruby2.5 | ruby2.7 | provided | provided.al2`
+* runtime - The identifier of the function's runtime. `nodejs12.x | nodejs14.x | nodejs16.x | java8 | java8.al2 | java11 | python2.7 | python3.6 | python3.7 | python3.8 | dotnetcore2.1 | dotnetcore3.1 | go1.x | ruby2.5 | ruby2.7 | provided | provided.al2`
 * environment - Lambda Environment variables. example: `foo=bar,author=appleboy`
 * image_uri - URI of a container image in the Amazon ECR registry.
 * subnets - Select the VPC subnets for Lambda to use to set up your VPC configuration.


### PR DESCRIPTION
Hey,

just a small readme.md update to show only the node versions supported was lambda. 

Node 10.x has been sunset: [Source](https://aws.amazon.com/de/blogs/developer/announcing-the-end-of-support-for-node-js-10-x-in-the-aws-sdk-for-javascript-v3/)

And Node 12.x won't be supported in the near future. I did leave it in here though because they still support it until September. [Source](https://aws.amazon.com/de/blogs/developer/announcing-the-end-of-support-for-node-js-12-x-in-the-aws-sdk-for-javascript-v3/)

[Source for identifers](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)

Thank you for the lambda-action project. It improves my dev experience.

Dennis

