### PR TITLE
chore: update Dockerfile base image version to 1.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/appleboy/drone-lambda:1.3.2
+FROM ghcr.io/appleboy/drone-lambda:1.3.3
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
- Update the base image version from 1.3.2 to 1.3.3 in Dockerfile
- Fix #25 