### PR TITLE
ci: update Drone-Lambda Docker image and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,17 @@ jobs:
           debug: true
           description: update description from github actions
 
+      - name: check publish flag
+        uses: ./
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: ${{ secrets.AWS_REGION }}
+          function_name: gorush
+          zip_file: example/deployment.zip
+          debug: true
+          publish: false
+
   # deploy_source:
   #   name: deploy lambda from source
   #   runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/appleboy/drone-lambda:1.3.3
+FROM ghcr.io/appleboy/drone-lambda:1.3.4
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
- Update the `Drone-Lambda` Docker image from version `1.3.3` to `1.3.4`
- Add a new step to the CI workflow to check the publish flag before deploying to AWS Lambda

fix https://github.com/appleboy/lambda-action/issues/42