### PR TITLE
docs: integrate AWS policy for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,18 +130,3 @@ jobs:
           aws_region: ${{ secrets.AWS_REGION }}
           function_name: gorush
           source: example/main.go,example/go.mod,example/go.sum
-
-  # deploy_source:
-  #   name: deploy lambda from source
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: checkout source code
-  #       uses: actions/checkout@v3
-  #     - name: default deploy
-  #       uses: appleboy/lambda-action@master
-  #       with:
-  #         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws_region: ${{ secrets.AWS_REGION }}
-  #         function_name: gorush
-  #         source: example/main.go

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Add the following AWS policy if you want to integrate with GitHub Actions. Pleas
         "iam:ListRoles",
         "lambda:UpdateFunctionCode",
         "lambda:CreateFunction",
+        "lambda:GetFunction",
         "lambda:UpdateFunctionConfiguration",
         "lambda:GetFunctionConfiguration"
       ],


### PR DESCRIPTION
- Remove commented out code for deploying source code to AWS lambda
- Add an AWS policy to README.md for GitHub Actions integration

fix #58 
fix #63 